### PR TITLE
Add support for Ubuntu 10.04's version of Upstart

### DIFF
--- a/templates/default/statsd.conf.erb
+++ b/templates/default/statsd.conf.erb
@@ -8,10 +8,16 @@ respawn
 respawn limit 5 30
 
 chdir /usr/share/statsd
+<% unless node['platform_version'].to_f < 11.10 -%>
 setuid statsd
+<% end %>
 
 script
+<% if node['platform_version'].to_f < 11.10 -%>
+  exec start-stop-daemon --start --chuid statsd --exec /usr/local/bin/node /usr/share/statsd/stats.js /etc/statsd/config.js 2>&1 >> <%= @log_file %>
+<% else -%>
   exec /usr/local/bin/node /usr/share/statsd/stats.js /etc/statsd/config.js 2>&1 >> <%= @log_file %>
+<% end -%>
 end script
 
 emits statsd-running


### PR DESCRIPTION
The init file contains setuid, which doesn't work in Lucid's version of Upstart (0.6.5). Added a little bit of logic to use start-stop-daemon instead to achieve the same effect when running under Lucid or Maverick.
