### PR TITLE
Update upstart script with absolute path for node

### DIFF
--- a/templates/default/statsd.conf.erb
+++ b/templates/default/statsd.conf.erb
@@ -14,9 +14,9 @@ setuid statsd
 
 script
 <% if @platform_version < 11.10 -%>
-  exec start-stop-daemon --start --chuid statsd --exec node /usr/share/statsd/stats.js /etc/statsd/config.js 2>&1 >> <%= @log_file %>
+  exec start-stop-daemon --start --chuid statsd --exec <%= node['nodejs']['dir'] %>/bin/node /usr/share/statsd/stats.js /etc/statsd/config.js 2>&1 >> <%= @log_file %>
 <% else -%>
-  exec node /usr/share/statsd/stats.js /etc/statsd/config.js 2>&1 >> <%= @log_file %>
+  exec <%= node['nodejs']['dir'] %>/bin/node /usr/share/statsd/stats.js /etc/statsd/config.js 2>&1 >> <%= @log_file %>
 <% end -%>
 end script
 


### PR DESCRIPTION
I'm not sure why, but the upstart script will only work on my ubuntu (11.04) instances if the absolute path is specified in the upstart script.  I'm not sure if this is happening for others or not.  I also am not sure if referencing attributes from another cookbook is a good idea, but since it's a dependency for this one I expect it's not an issue.
