### PR TITLE
Delete this little comma?

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -41,7 +41,7 @@ when "rhel","fedora"
     mode "0755"
     source "statsd.erb"
     variables(
-      :log_file         => node["statsd"]["log_file"],
+      :log_file         => node["statsd"]["log_file"]
     )
   end
 end


### PR DESCRIPTION
If I don't delete this little comma at the end, I get this error:

```
[2013-01-25T16:49:43-08:00] INFO: *** Chef 10.18.2 ***
[2013-01-25T16:49:43-08:00] INFO: Setting the run_list to ["recipe[sr-statsd::default]", "recipe[statsd]"] from JSON
[2013-01-25T16:49:43-08:00] INFO: Run List is [recipe[sr-statsd::default], recipe[statsd]]
[2013-01-25T16:49:43-08:00] INFO: Run List expands to [sr-statsd::default, statsd]
[2013-01-25T16:49:43-08:00] INFO: Starting Chef Run for sr-statsd-berkshelf
[2013-01-25T16:49:43-08:00] INFO: Running start handlers
[2013-01-25T16:49:43-08:00] INFO: Start handlers complete.

================================================================================

Recipe Compile Error in /tmp/vagrant-chef-1/chef-solo-1/cookbooks/statsd/recipes/default.rb

================================================================================


SyntaxError

-----------

compile error
/tmp/vagrant-chef-1/chef-solo-1/cookbooks/statsd/recipes/default.rb:45: syntax error, unexpected ')'
/tmp/vagrant-chef-1/chef-solo-1/cookbooks/statsd/recipes/default.rb:77: syntax error, unexpected $end, expecting kEND


Cookbook Trace:

---------------

  /tmp/vagrant-chef-1/chef-solo-1/cookbooks/statsd/recipes/default.rb:77:in `from_file'


Relevant File Content:

----------------------

/tmp/vagrant-chef-1/chef-solo-1/cookbooks/statsd/recipes/default.rb:

 70:      if node["platform_version"].to_f >= 9.10
 71:        provider Chef::Provider::Service::Upstart
 72:      end
 73:      #restart_command "sudo service statsd stop && sudo service statsd start"
 74:    end
 75:    action [ :enable, :start ]
 76:    supports :start => true, :stop => true, :restart => true, :status => true
 77>> end
 78:  


[2013-01-25T16:49:43-08:00] ERROR: Running exception handlers
[2013-01-25T16:49:43-08:00] ERROR: Exception handlers complete
[2013-01-25T16:49:43-08:00] FATAL: Stacktrace dumped to /tmp/vagrant-chef-1/chef-stacktrace.out
[2013-01-25T16:49:43-08:00] FATAL: SyntaxError: compile error
/tmp/vagrant-chef-1/chef-solo-1/cookbooks/statsd/recipes/default.rb:45: syntax error, unexpected ')'
/tmp/vagrant-chef-1/chef-solo-1/cookbooks/statsd/recipes/default.rb:77: syntax error, unexpected $end, expecting kEND
Chef never successfully completed! Any errors should be visible in the
output above. Please fix your recipes so that they properly complete.
```

To be honest, I'm not sure what this did. Can some light be shed on this? I'm running the receipe from Berkshelf with a standard Vagrant precise64 image.
