### PR TITLE
Fix for rhel, fedora system V init template, removed hardcoded statsd path

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -41,7 +41,8 @@ when "rhel","fedora"
     mode "0755"
     source "statsd.erb"
     variables(
-      :log_file         => node["statsd"]["log_file"]
+      :log_file         => node["statsd"]["log_file"],
+      :node_dir         => node["statsd"]["dir"]
     )
   end
 end

--- a/templates/default/statsd.erb
+++ b/templates/default/statsd.erb
@@ -21,7 +21,7 @@
 . /etc/rc.d/init.d/functions
 
 NAME=statsd
-INSTALL_DIR=/usr/share/$NAME
+INSTALL_DIR=<%= @node_dir %>
 NODE_EXE=/usr/local/bin/node
 
 [ -x $NODE_EXE ] || exit 0


### PR DESCRIPTION
Init script fails to start when default statsd location changed.
