### PR TITLE
Allow Configuration of Graphite legacyNamespace

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -7,3 +7,4 @@ default["statsd"]["address"]        = "0.0.0.0"
 default["statsd"]["port"]           = 8125
 default["statsd"]["graphite_host"]  = "localhost"
 default["statsd"]["graphite_port"]  = 2003
+default["statsd"]["graphite"]["legacy_namespace"] = true

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -20,7 +20,8 @@ template "#{node["statsd"]["conf_dir"]}/config.js" do
     :port           => node["statsd"]["port"],
     :flush_interval => node["statsd"]["flush_interval"],
     :graphite_port  => node["statsd"]["graphite_port"],
-    :graphite_host  => node["statsd"]["graphite_host"]
+    :graphite_host  => node["statsd"]["graphite_host"],
+    :legacy_namespace => node["statsd"]["graphite"]["legacy_namespace"]
   )
   notifies :restart, "service[statsd]"
 end

--- a/templates/default/config.js.erb
+++ b/templates/default/config.js.erb
@@ -3,5 +3,8 @@
   "graphiteHost": "<%= @graphite_host %>",
   "address": "<%= @address %>",
   "port": <%= @port %>,
-  "flushInterval": <%= @flush_interval %>
+  "flushInterval": <%= @flush_interval %>,
+    "graphite": {
+      "legacyNamespace": <%= @legacy_namespace %>
+  }
 }


### PR DESCRIPTION
Added an attribute to allow for legacyNamespace config to be specified. Defaults to statsd default of true.
