### PR TITLE
Add ability to discover graphite host

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -5,8 +5,10 @@ default["statsd"]["log_file"]                     = "/var/log/statsd.log"
 default["statsd"]["flush_interval"]               = 10000
 default["statsd"]["address"]                      = "0.0.0.0"
 default["statsd"]["port"]                         = 8125
-default["statsd"]["graphite_host"]                = "localhost"
+default["statsd"]["graphite_host"]                = "127.0.0.1"
 default["statsd"]["graphite_port"]                = 2003
+default['statsd']['graphite_role']                = 'graphite_server'
+default['statsd']['graphite_query']               = "roles:#{node['statsd']['graphite_role']} AND chef_environment:#{node.chef_environment}"
 default["statsd"]["delete_timers"]                = false
 default["statsd"]["delete_gauges"]                = false
 

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -12,6 +12,16 @@ directory node["statsd"]["conf_dir"] do
   action :create
 end
 
+graphite_host = node['statsd']['graphite_host']
+
+unless Chef::Config[:solo]
+  graphite_results = search(:node, node['statsd']['graphite_query'])
+
+  unless graphite_results.empty?
+    graphite_host = graphite_results[0]['ipaddress']
+  end
+end
+
 template "#{node["statsd"]["conf_dir"]}/config.js" do
   mode "0644"
   source "config.js.erb"
@@ -20,7 +30,7 @@ template "#{node["statsd"]["conf_dir"]}/config.js" do
     :port             => node["statsd"]["port"],
     :flush_interval   => node["statsd"]["flush_interval"],
     :graphite_port    => node["statsd"]["graphite_port"],
-    :graphite_host    => node["statsd"]["graphite_host"],
+    :graphite_host    => graphite_host,
     :delete_gauges    => node["statsd"]["delete_gauges"],
     :delete_timers    => node["statsd"]["delete_timers"],
     :legacy_namespace => node["statsd"]["graphite"]["legacy_namespace"],


### PR DESCRIPTION
Allows the user to specify a query(graphite_query) to search for the graphite_host.
