### PR TITLE
Fix notification reference to runit service, delay notification until end of chef run

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -5,7 +5,7 @@ include_recipe "runit"
 git node["statsd"]["dir"] do
   repository node["statsd"]["repository"]
   action :sync
-  notifies :restart, "runit_service[statsd]"
+  notifies :restart, "service[statsd]", :delayed
 end
 
 directory node["statsd"]["conf_dir"] do
@@ -30,7 +30,7 @@ template "#{node["statsd"]["conf_dir"]}/config.js" do
     :prefix_gauge     => node["statsd"]["graphite"]["prefix_gauge"],
     :prefix_set       => node["statsd"]["graphite"]["prefix_set"]
   )
-  notifies :restart, "runit_service[statsd]"
+  notifies :restart, "service[statsd]", :delayed
 end
 
 user node["statsd"]["username"] do


### PR DESCRIPTION
Fixes the reference to the runit service, fixing the following bug:

```
FATAL: Chef::Exceptions::ResourceNotFound: resource git[/usr/share/statsd] is configured to notify resource runit_service[statsd] with action restart, but runit_service[statsd] cannot be found in the resource collection. git[/usr/share/statsd] is defined in /var/cache/chef/cookbooks/statsd/recipes/default.rb:5:in `from_file'
```

Added the delay flag to consolidate multiple restarts when code and configuration are deployed
