### PR TITLE
Support the 'percentThreshold' option

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Installs and configures StatsD.
 * `node["statsd"]["repository"]` - Reference to a StatsD repository.
 * `node["statsd"]["log_file"]` - Path to the StatsD log file.
 * `node["statsd"]["flush_interval"]` - Flush interval in milliseconds.
+* `node["statsd"]["percent_threshold"]` - Nth percentile value(s). Single value or array.
 * `node["statsd"]["address"]` - Address to bind StatsD to.
 * `node["statsd"]["port"]` - Port to run StatsD on.
 * `node["statsd"]["graphite_host"]` - Graphite host.

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -2,6 +2,7 @@ default["statsd"]["dir"]                          = "/usr/share/statsd"
 default["statsd"]["conf_dir"]                     = "/etc/statsd"
 default["statsd"]["repository"]                   = "git://github.com/etsy/statsd.git"
 default["statsd"]["flush_interval"]               = 10000
+default["statsd"]["percent_threshold"]            = "90"
 default["statsd"]["address"]                      = "0.0.0.0"
 default["statsd"]["port"]                         = 8125
 default["statsd"]["graphite_host"]                = "127.0.0.1"

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -29,6 +29,7 @@ template "#{node["statsd"]["conf_dir"]}/config.js" do
     :address            => node["statsd"]["address"],
     :port               => node["statsd"]["port"],
     :flush_interval     => node["statsd"]["flush_interval"],
+    :percent_threshold  => node["statsd"]["percent_threshold"],
     :graphite_port      => node["statsd"]["graphite_port"],
     :graphite_host      => graphite_host,
     :delete_idle_stats  => node["statsd"]["delete_idle_stats"],

--- a/templates/default/config.js.erb
+++ b/templates/default/config.js.erb
@@ -4,6 +4,7 @@
   "address": "<%= @address %>",
   "port": <%= @port %>,
   "flushInterval": <%= @flush_interval %>,
+  "percentThreshold": <%= @percent_threshold %>,
   "deleteIdleStats": <%= @delete_idle_stats %>,
   "deleteGauges": <%= @delete_gauges %>,
   "deleteTimers": <%= @delete_timers %>,


### PR DESCRIPTION
Added support for the statsd 'percentThreshold' option.

From https://github.com/etsy/statsd/blob/master/exampleConfig.js :

> percentThreshold: for time information, calculate the Nth percentile(s)
>                    (can be a single value or list of floating-point values)
>                    negative values mean to use "top" Nth percentile(s) values
>                    [%, default: 90]
