### PR TITLE
Updated default statsd URL from git:// to http://

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,6 +1,6 @@
 default["statsd"]["dir"]                          = "/usr/share/statsd"
 default["statsd"]["conf_dir"]                     = "/etc/statsd"
-default["statsd"]["repository"]                   = "git://github.com/etsy/statsd.git"
+default["statsd"]["repository"]                   = "http://github.com/etsy/statsd.git"
 default["statsd"]["flush_interval"]               = 10000
 default["statsd"]["percent_threshold"]            = 90
 default["statsd"]["address"]                      = "0.0.0.0"


### PR DESCRIPTION
git ports may not be allowed in some environments. http is more compatible by default.
