### PR TITLE
Use attributes to specify statsd revision

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Installs and configures StatsD.
 * `node["statsd"]["dir"]` - Directory to install into.
 * `node["statsd"]["conf_dir"]` - Directory for StatsD configuration.
 * `node["statsd"]["repository"]` - Reference to a StatsD repository.
-* `node["statsd"]["revision"]` - Revision of repository to checkout.
+* `node["statsd"]["reference"]` - Revision of repository to checkout.
 * `node["statsd"]["log_file"]` - Path to the StatsD log file.
 * `node["statsd"]["flush_interval"]` - Flush interval in milliseconds.
 * `node["statsd"]["percent_threshold"]` - Nth percentile value(s). Single value or array.

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,7 +1,7 @@
 default["statsd"]["dir"]                          = "/usr/share/statsd"
 default["statsd"]["conf_dir"]                     = "/etc/statsd"
 default["statsd"]["repository"]                   = "http://github.com/etsy/statsd.git"
-default["statsd"]["revision"]                     = "master"
+default["statsd"]["reference"]                    = "master"
 default["statsd"]["flush_interval"]               = 10000
 default["statsd"]["percent_threshold"]            = 90
 default["statsd"]["address"]                      = "0.0.0.0"

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -4,7 +4,7 @@ include_recipe "runit"
 
 git node["statsd"]["dir"] do
   repository node["statsd"]["repository"]
-  reference node["statsd"]["revision"]
+  reference node["statsd"]["reference"]
   action :sync
   notifies :restart, "runit_service[statsd]"
 end


### PR DESCRIPTION
So that users may pin to specific revisions of statsd.
Defaults to master.
