### PR TITLE
Allow nodejs_dir to be set by nodejs cookbook attribute

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -59,6 +59,7 @@ runit_service "statsd" do
   options ({
     :user => node['statsd']['username'],
     :statsd_dir => node['statsd']['dir'],
-    :conf_dir => node['statsd']['conf_dir']
+    :conf_dir => node['statsd']['conf_dir'],
+    :nodejs_dir => node['nodejs']['dir']                    
   })
 end

--- a/templates/default/sv-statsd-run.erb
+++ b/templates/default/sv-statsd-run.erb
@@ -1,4 +1,4 @@
 #!/bin/sh
 exec 2>&1
-exec chpst -u <%= @options[:user] %> /usr/local/bin/node <%= @options[:statsd_dir] %>/stats.js <%= @options[:conf_dir] %>/config.js
+exec chpst -u <%= @options[:user] %> <%= @options[:nodejs_dir] %>/bin/node <%= @options[:statsd_dir] %>/stats.js <%= @options[:conf_dir] %>/config.js
 


### PR DESCRIPTION
Allow the nodejs cookbook attribute `node[:nodejs][:dir]` to set the node directory. 

E.g. packages that install node to `/usr/bin/node` instead of `/usr/local/bin/node`
