### PR TITLE
Allow configuring dumpMessages through node attribute

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -16,6 +16,7 @@ default["statsd"]["delete_gauges"]                = false
 default["statsd"]["delete_sets"]                  = false
 default["statsd"]["delete_counters"]              = false
 default["statsd"]["username"]                     = "statsd"
+default["statsd"]["dump_messages"]                = false
 
 # Graphite storage config
 default["statsd"]["graphite"]["legacy_namespace"] = true

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -43,7 +43,8 @@ template "#{node["statsd"]["conf_dir"]}/config.js" do
     :prefix_counter     => node["statsd"]["graphite"]["prefix_counter"],
     :prefix_timer       => node["statsd"]["graphite"]["prefix_timer"],
     :prefix_gauge       => node["statsd"]["graphite"]["prefix_gauge"],
-    :prefix_set         => node["statsd"]["graphite"]["prefix_set"]
+    :prefix_set         => node["statsd"]["graphite"]["prefix_set"],
+    :dump_messages      => node["statsd"]["dump_messages"]
   )
   notifies :restart, "service[statsd]", :delayed
 end

--- a/templates/default/config.js.erb
+++ b/templates/default/config.js.erb
@@ -17,5 +17,6 @@
     "prefixTimer": "<%= @prefix_timer %>",
     "prefixGauge": "<%= @prefix_gauge %>",
     "prefixSet": "<%= @prefix_set %>"
-  }
+  },
+  "dumpMessages": "<%= @dump_messages %>"
 }


### PR DESCRIPTION
When debugging statsd (specifically logstash output) I have found
it useful to keep dumpMessages on.
