### PR TITLE
Make sure globalSuffix is undefined when not used.

### DIFF
--- a/templates/default/config.js.erb
+++ b/templates/default/config.js.erb
@@ -13,7 +13,11 @@
   "graphite": {
     "legacyNamespace": <%= @legacy_namespace %>,
     "globalPrefix": "<%= @global_prefix %>",
+<% if !@global_suffix.empty? %>
     "globalSuffix": "<%= @global_suffix %>",
+<% else %>
+    "globalSuffix": undefined,
+<% end %>
     "prefixCounter": "<%= @prefix_counter %>",
     "prefixTimer": "<%= @prefix_timer %>",
     "prefixGauge": "<%= @prefix_gauge %>",


### PR DESCRIPTION
Otherwise, StatsD will create metrics like '.../metric/rate/.wsp'
instead of '.../metric/rate.wsp'.

This fixes the regression that ended up in 1.1.7. See #31.
