### PR TITLE
introduce nodejs_bin to replace inheritance of nodejs_dir

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -26,3 +26,6 @@ default["statsd"]["graphite"]["prefix_counter"]   = "counters"
 default["statsd"]["graphite"]["prefix_timer"]     = "timers"
 default["statsd"]["graphite"]["prefix_gauge"]     = "gauges"
 default["statsd"]["graphite"]["prefix_set"]       = "sets"
+
+# nodejs
+default["statsd"]["nodejs_bin"] = "#{node["nodejs"]["dir"]}/bin/node"

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -62,6 +62,6 @@ runit_service "statsd" do
     :user => node['statsd']['username'],
     :statsd_dir => node['statsd']['dir'],
     :conf_dir => node['statsd']['conf_dir'],
-    :nodejs_dir => node['nodejs']['dir']
+    :nodejs_bin => node['statsd']['nodejs_bin']
   })
 end

--- a/templates/default/sv-statsd-run.erb
+++ b/templates/default/sv-statsd-run.erb
@@ -1,4 +1,4 @@
 #!/bin/sh
 exec 2>&1
-exec chpst -u <%= @options[:user] %> <%= @options[:nodejs_dir] %>/bin/node <%= @options[:statsd_dir] %>/stats.js <%= @options[:conf_dir] %>/config.js
+exec chpst -u <%= @options[:user] %> <%= @options[:nodejs_bin] %> <%= @options[:statsd_dir] %>/stats.js <%= @options[:conf_dir] %>/config.js
 


### PR DESCRIPTION
if you use node['nodejs']['install_method'] = 'package' then node['nodejs']['dir'] doesn't really make sense.
since the init script only needs the binary, it should just allow you to set the binary.

also backwards compatible with current setup.
