### PR TITLE
Output dumpMessages config value as a boolean

### DIFF
--- a/templates/default/config.js.erb
+++ b/templates/default/config.js.erb
@@ -23,5 +23,5 @@
     "prefixGauge": "<%= @prefix_gauge %>",
     "prefixSet": "<%= @prefix_set %>"
   },
-  "dumpMessages": "<%= @dump_messages %>"
+  "dumpMessages": <%= @dump_messages %>
 }


### PR DESCRIPTION
Currently it outputs as a string, which is interpreted as truthy causing all metrics to be logged.
