### PR TITLE
Use poise_service for statsd service management

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -6,10 +6,10 @@ version           "1.1.12"
 recipe            "statsd", "Installs and configures StatsD"
 name              "statsd"
 
-%w{ git nodejs runit }.each do |d|
+%w(git nodejs poise-service-runit).each do |d|
   depends d
 end
 
-%w{ debian ubuntu rhel scientific redhat centos amazon}.each do |os|
+%w(debian ubuntu rhel scientific redhat centos amazon).each do |os|
   supports os
 end

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -6,7 +6,7 @@ git node["statsd"]["dir"] do
   repository node["statsd"]["repository"]
   reference node["statsd"]["reference"]
   action :sync
-  notifies :restart, "service[statsd]", :delayed
+  notifies :restart, "poise_service[statsd]", :delayed
 end
 
 directory node["statsd"]["conf_dir"] do
@@ -50,7 +50,7 @@ template "#{node["statsd"]["conf_dir"]}/config.js" do
     :debug              => node["statsd"]["debug"],
     :dump_messages      => node["statsd"]["dump_messages"]
   )
-  notifies :restart, "service[statsd]", :delayed
+  notifies :restart, "poise_service[statsd]", :delayed
 end
 
 user node["statsd"]["username"] do
@@ -58,13 +58,8 @@ user node["statsd"]["username"] do
   shell "/bin/false"
 end
 
-runit_service "statsd" do
-  action [:enable, :start]
-  default_logger true
-  options ({
-    :user => node['statsd']['username'],
-    :statsd_dir => node['statsd']['dir'],
-    :conf_dir => node['statsd']['conf_dir'],
-    :nodejs_bin => node['statsd']['nodejs_bin']
-  })
+poise_service 'statsd' do
+  provider :runit
+  user node['statsd']['username']
+  command "#{node['statsd']['nodejs_bin']} #{node['statsd']['dir']}/stats.js #{node['statsd']['conf_dir']}/config.js"
 end

--- a/templates/default/sv-statsd-log-run.erb
+++ b/templates/default/sv-statsd-log-run.erb
@@ -1,2 +1,0 @@
-#!/bin/sh
-exec svlogd -tt ./main

--- a/templates/default/sv-statsd-run.erb
+++ b/templates/default/sv-statsd-run.erb
@@ -1,4 +1,0 @@
-#!/bin/sh
-exec 2>&1
-exec chpst -u <%= @options[:user] %> <%= @options[:nodejs_bin] %> <%= @options[:statsd_dir] %>/stats.js <%= @options[:conf_dir] %>/config.js
-


### PR DESCRIPTION
Checkout this [cool project](https://github.com/poise/poise-service). It allows to do the same thing easier and supports several service providers. You don't need custom templates for runit anymore.

Also it has a little hack for runit cookbook problem that leads to errors while running in docker without runsvdir.
